### PR TITLE
Implement strafing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Your objective is to navigate the map and activate exit elevator, killing hoards
 
 Controls:
 * WASD - movement
+* J/L - turn
 * p - shoot
 * num 1-4 - change color mode (4 is my favorite)
 * x - activate elevator (arrives after 1000 moves)

--- a/awkaster.awk
+++ b/awkaster.awk
@@ -498,12 +498,20 @@ function main()
     close(cmd)
     system("stty echo")
 
-    if (input == "w" || input == "s"){
+    if (input == "w" || input == "s" || input == "a" || input == "d"){
       newPosX = posX - dirX * moveSpeed;
       newPosY = posY - dirY * moveSpeed;
       if (input == "w") {
         newPosX = posX + dirX * moveSpeed;
         newPosY = posY + dirY * moveSpeed;
+      }
+      if (input == "a") {
+        newPosX = posX - dirY * moveSpeed;
+        newPosY = posY + dirX * moveSpeed;
+      }
+      if (input == "d") {
+        newPosX = posX + dirY * moveSpeed;
+        newPosY = posY - dirX * moveSpeed;
       }
       ok = 1;
       for(i in sprite) {
@@ -516,9 +524,9 @@ function main()
         if(worldMap(posX,newPosY) == 0) posY = newPosY;
       }
     }
-    if (input == "a" || input == "d"){
+    if (input == "j" || input == "l"){
       rot = rotSpeed
-      if (input == "d")
+      if (input == "l")
         rot = -rot
       #both camera direction and camera plane must be rotated
       oldDirX = dirX


### PR DESCRIPTION
Make A/D strafe left/right, and use j/l to turn.

This is a more traditional interpretation of WASD controls, and being
able to strafe around corners is a classic vital FPS technique.

Ideally we'd use the arrow keys for turning, but that'd require
revamping the input mechanism somewhat (probably doable via `stty
-cbreak` or so).
