### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# To run use:
+#    docker build -t awk-raycaster .
+#    docker run --rm -it awk-raycaster
+
+FROM alpine:latest
+RUN apk update && apk add gawk
+COPY awkaster.awk /build/awkaster.awk
+ENTRYPOINT ["gawk", "-f", "/build/awkaster.awk"]


### PR DESCRIPTION
Allows users to run in a docker container.

Automated image building can be turned on in dockerhub which removes the need to build before running.

## Usage:
```shell
docker build -t awk-raycaster .
docker run --rm -it awk-raycaster
```